### PR TITLE
[automated-generated-pr] ci: disable scheduled trigger

### DIFF
--- a/.github/workflows/trigger-workflow.yml
+++ b/.github/workflows/trigger-workflow.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ "main" ]
   workflow_dispatch:
-  schedule:
-    - cron: '0 13 * * *'
 
 jobs:
   call_reusable_workflow:


### PR DESCRIPTION
This PR disables the scheduled trigger in the workflow to prevent GitHub from freezing the workflow runs after 60 days of inactivity.